### PR TITLE
Unity Asset Import Order Workaround

### DIFF
--- a/Assets/Editor/Editor Window/ModelColourEditorSettings.cs
+++ b/Assets/Editor/Editor Window/ModelColourEditorSettings.cs
@@ -17,7 +17,7 @@ namespace ModelColourEditor
     public class ModelColourEditorSettings : ScriptableObject
     {
         private const string EDITOR_PREFS_KEY = "ModelColourEditor.Settings";
-
+        private const string CACHE_FILE_PATH  = "Assets/ModelColourEditor.cache";
         public static bool HasAsset { get; private set; }
 
         private static ModelColourEditorSettings _instance;


### PR DESCRIPTION
Provides a work-around solution for a chicken-and-egg issue when performing first time imports of projects that use this tool.

We now write a simple test file that contains two pieces of information:
The asset GUID of the defaultMaterial
The value for the importMaterialColoursByDefault flag

Explainer from comments:

> About caching our settings to a text file:
> During a fresh import, ModelColourEditorSettings.Instance fails to load from asset database due to the order of Unitys import process.
> This results in the plugin generating a fresh settings instance as a fallback, with an null default material and importByDefault set to false.
> Unfortunately, ScriptableObjects import way later than primitive asset types like shaders, materials and textures and unfortunately, models.
> So as a workaround, we stash any non-default values into a json-formatted .cache file.
> Text storage is required for a few reason:
> Storing the cache file in git to be shared across collaborators
> Allows us to use File.ReadAllText to work outside of the asset import order.
>         
> An alternative could have been to remove the Settings ScriptableObject asset entirely, and write settings to an auto-generated script, but this is not viable when using ModelColourEditor through the package manager.
> This is because we cannot reliably modify scripts that reside in the package cache, and it's not simply to grant package scripts exposure to scripts that reside inside the main project assemblies. 